### PR TITLE
Fix build on OSX by telling CMake we require C++14

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,7 @@
 cmake_minimum_required(VERSION 3.5)
+
+set (CMAKE_CXX_STANDARD 14)
+
 project(x86-to-6502)
 
 if(CMAKE_COMPILER_IS_GNUCC)


### PR DESCRIPTION
Apparently on Apple Clang, C++14 is not enabled by default. We can tell CMake we expect C++14 by adding this. This should still work on Linux also, as this is just a standard CMake feature that gives the appropriate flags to the compiler if needed.

Otherwise the output is this (truncated):
```
main.cpp:12:8: warning: scoped enumerations are a C++11 extension
      [-Wc++11-extensions]
  enum class Type
main.cpp:135:12: error: expression is not an integral constant
      expression
      case OpCode::beq:
```